### PR TITLE
faster cleanup function

### DIFF
--- a/lib/objects/ariadne_object.php
+++ b/lib/objects/ariadne_object.php
@@ -1699,7 +1699,7 @@ debug("loadLibrary: loading cache for $this->path");
 						if ($subcpos = strpos($arType, '.')) {
 							$arSuper = substr($arType, 0, $subcpos);
 						} else {
-							if (!class_exists($arType)) {
+							if (!class_exists($arType, false )) {
 								// the given class was not yet loaded, so do that now
 								$arTemp=$this->store->newobject('','',$arType,new object);
 							} else {

--- a/lib/objects/ariadne_object.php
+++ b/lib/objects/ariadne_object.php
@@ -1208,11 +1208,11 @@ abstract class ariadne_object extends object { // ariadne_object class definitio
 	global $ARConfig;
 		$path = $this->make_path($path);
 		if ($ARConfig->cache[$path]) {
-			foreach ($ARConfig->cache as $cachepath => $cache) {
-				if (strpos($cachepath, $path) === 0) {
-					unset($ARConfig->cache[$cachepath]);
-					unset($ARConfig->pinpcache[$cachepath]);
-				}
+			$path = preg_quote($path,'/');
+			$keys = preg_grep('/'.$path.'/',array_keys($ARConfig->cache));
+			foreach ($keys as $cachepath) {
+				unset($ARConfig->cache[$cachepath]);
+				unset($ARConfig->pinpcache[$cachepath]);
 			}
 		}
 	}
@@ -1220,14 +1220,13 @@ abstract class ariadne_object extends object { // ariadne_object class definitio
 	public function clearChildConfigs($path='') {
 	global $ARConfig;
 		$path = $this->make_path($path);
-		$pathlength = strlen($path);
 		if ($ARConfig->cache[$path]) {
-			foreach ($ARConfig->cache as $cachepath => $cache) {
-				if (strpos($cachepath, $path) === 0 && strlen($cachepath)>$pathlength) {
-					unset($ARConfig->cache[$cachepath]);
-					unset($ARConfig->pinpcache[$cachepath]);
-					unset($ARConfig->libraries[$cachepath]);
-				}
+			$path = preg_quote($path,'/');
+			$keys = preg_grep('/'.$path.'./',array_keys($ARConfig->cache));
+			foreach($keys as $cachepath) {
+				unset($ARConfig->cache[$cachepath]);
+				unset($ARConfig->pinpcache[$cachepath]);
+				unset($ARConfig->libraries[$cachepath]);
 			}
 		}
 	}

--- a/lib/objects/ariadne_object.php
+++ b/lib/objects/ariadne_object.php
@@ -1714,9 +1714,10 @@ debug("loadLibrary: loading cache for $this->path");
 			}
 			if ($inLibrary) {
 
-				list($basetype,) = explode('.', $ARConfig->cache[$checkpath]->type,2);
-				//debug("getPinpTemplate; INLIBRARY $checkpath; ".$basetype);
-				if ($basetype == 'psection') {
+				// faster matching on psection, prefix doesn't have to be a valid type
+				$basetype = substr($ARConfig->cache[$checkpath]->type,0,8);
+
+				if ($prefix === 'psection') {
 					// debug("BREAKING; $arTemplateId");
 					// break search operation when we have found a
 					// psection object

--- a/lib/objects/ariadne_object.php
+++ b/lib/objects/ariadne_object.php
@@ -1715,7 +1715,7 @@ debug("loadLibrary: loading cache for $this->path");
 			if ($inLibrary) {
 
 				// faster matching on psection, prefix doesn't have to be a valid type
-				$basetype = substr($ARConfig->cache[$checkpath]->type,0,8);
+				$prefix = substr($ARConfig->cache[$checkpath]->type,0,8);
 
 				if ($prefix === 'psection') {
 					// debug("BREAKING; $arTemplateId");

--- a/lib/objects/ariadne_object.php
+++ b/lib/objects/ariadne_object.php
@@ -1209,7 +1209,7 @@ abstract class ariadne_object extends object { // ariadne_object class definitio
 		$path = $this->make_path($path);
 		if ($ARConfig->cache[$path]) {
 			$path = preg_quote($path,'/');
-			$keys = preg_grep('/'.$path.'/',array_keys($ARConfig->cache));
+			$keys = preg_grep('/^'.$path.'/',array_keys($ARConfig->cache));
 			foreach ($keys as $cachepath) {
 				unset($ARConfig->cache[$cachepath]);
 				unset($ARConfig->pinpcache[$cachepath]);
@@ -1222,7 +1222,7 @@ abstract class ariadne_object extends object { // ariadne_object class definitio
 		$path = $this->make_path($path);
 		if ($ARConfig->cache[$path]) {
 			$path = preg_quote($path,'/');
-			$keys = preg_grep('/'.$path.'./',array_keys($ARConfig->cache));
+			$keys = preg_grep('/^'.$path.'./',array_keys($ARConfig->cache));
 			foreach($keys as $cachepath) {
 				unset($ARConfig->cache[$cachepath]);
 				unset($ARConfig->pinpcache[$cachepath]);


### PR DESCRIPTION
cleanChildConfigs is called on every loadConfig, this change makes the function +- 50% faster resulting on +- 20% reduced runtime for requests which will use a lot of objects