### PR TITLE
fix the handing for max-age and s-max-age

### DIFF
--- a/lib/includes/loader.web.php
+++ b/lib/includes/loader.web.php
@@ -1052,8 +1052,8 @@
 						$browserCacheNoTransform = $browserCacheNoTransform || $pathCacheSetting['browserCacheNoTransform']; // If anyone says 'no-transform', make it so.
 						$browserCacheProxyRevalidate = $browserCacheProxyRevalidate || $pathCacheSetting['browserCacheProxyRevalidate']; // If anyone says 'proxy-revalidate', make it so.
 
-						$browserCacheMaxAge = isset($pathCacheSetting['browserCacheMaxAge']) ? min($browserCacheMaxAge, $pathCacheSetting['browserCacheMaxAge']) : $browserCacheMaxAge;
-						$browserCacheSMaxAge = isset($pathCacheSetting['browserCacheSMaxAge']) ? min($browserCacheSMaxAge, $pathCacheSetting['browserCacheSMaxAge']) : $browserCacheSMaxAge;
+						$browserCacheMaxAge = (isset($pathCacheSetting['browserCacheMaxAge']) && $pathCacheSetting['browserCacheMaxAge'] !== '') ? min($browserCacheMaxAge, $pathCacheSetting['browserCacheMaxAge']) : $browserCacheMaxAge;
+						$browserCacheSMaxAge = (isset($pathCacheSetting['browserCacheSMaxAge']) && $pathCacheSetting['browserCacheSMaxAge'] !== '') ? min($browserCacheSMaxAge, $pathCacheSetting['browserCacheSMaxAge']) : $browserCacheSMaxAge;
 					}
 				}
 

--- a/lib/templates/pobject/dialog.cache.form.php
+++ b/lib/templates/pobject/dialog.cache.form.php
@@ -56,7 +56,7 @@
 			</div>
 			<div class="field text">
 				<label for="browserCacheMaxAge"><?php echo $ARnls["ariadne:cache:max-age"]; ?></label>
-				<input type="text" id="browserCacheMaxAge" name="browserCacheMaxAge" size="4" maxlength="6" value="<?php echo isset($cacheSettings["browserCacheMaxAge"]) ? (int)$cacheSettings["browserCacheMaxAge"] : ""; ?>">
+				<input type="text" id="browserCacheMaxAge" name="browserCacheMaxAge" size="4" maxlength="6" value="<?php echo ($cacheSettings["browserCacheMaxAge"] !== '') ? (int)$cacheSettings["browserCacheMaxAge"] : ""; ?>">
 			</div>
 			<div class="field checkbox">
 				<input id="browserCacheNoCache" type="checkbox" name="browserCacheNoCache" value="1" <?php if ($cacheSettings["browserCacheNoCache"]) { echo "checked"; } ?>>
@@ -74,7 +74,7 @@
 		<fieldset id="proxyCache">
 			<div class="field text">
 				<label for="browserCacheSMaxAge"><?php echo $ARnls["ariadne:cache:s-max-age"]; ?></label>
-				<input type="text" id="browserCacheSMaxAge" name="browserCacheSMaxAge" size="4" maxlength="6" value="<?php echo isset($cacheSettings["browserCacheSMaxAge"]) ? (int)$cacheSettings["browserCacheSMaxAge"] : ""; ?>">
+				<input type="text" id="browserCacheSMaxAge" name="browserCacheSMaxAge" size="4" maxlength="6" value="<?php echo ($cacheSettings["browserCacheSMaxAge"]!== '') ? (int)$cacheSettings["browserCacheSMaxAge"] : ""; ?>">
 			</div>
 			<legend><?php echo $ARnls["ariadne:cache:proxycaching"]; ?></legend>
 			<div class="field checkbox">


### PR DESCRIPTION
prevent max-age from becoming 0 over and over again, effectively killing the browser cache 