### PR TITLE
stop writing old format compiled templates

### DIFF
--- a/lib/modules/mod_filestore.phtml
+++ b/lib/modules/mod_filestore.phtml
@@ -165,11 +165,10 @@
 			return $result;
 		}
 
-		public function templateCodeFunction($fsId, $fsName) {
+		public function templateCodeFunction($code) {
 				$template = 
 				' $local = new ar_core_pinpSandbox($AR_this); '.
-				' ?'.'>'.
-				$this->read($fsId, $fsName).
+				' ?'.'>'.$code.
 				'<'.'?php ';
 			return $template;
 		}

--- a/lib/templates/pobject/system.export.templates.phtml
+++ b/lib/templates/pobject/system.export.templates.phtml
@@ -58,10 +58,7 @@ if (! ( $templates && is_array($templates) && !empty($templates) ) && !$ARCurren
 								if ($pinp->error) {
 									$this->newObject->error = $pinp->error;
 								} else {
-									$new_filestore->write($compiled, $this->newObject->id, "$type.$function.$language");
-									$new_filestore->touch($this->newObject->id, "$type.$function.$language", $tmtime);
-
-									$templateCode = $new_filestore->templateCodeFunction($this->newObject->id, $type.".".$function.".".$language); 
+									$templateCode = $new_filestore->templateCodeFunction($compiled);
 
 									// generating optimized template code
 									$optimized = '<?php $arTemplateFunction = function(&$AR_this) { '.$templateCode.' }; ?>';

--- a/lib/templates/pobject/system.export.templates.phtml
+++ b/lib/templates/pobject/system.export.templates.phtml
@@ -45,11 +45,17 @@ if (! ( $templates && is_array($templates) && !empty($templates) ) && !$ARCurren
 							if ($default) {
 								$this->newObject->data->config->templates[$type][$function][$language] = $this->newObject->id;
 							}
-							$new_filestore->write($tdata, $this->newObject->id, "$type.$function.$language.pinp");
-							$new_filestore->touch($this->newObject->id, "$type.$function.$language.pinp", $tmtime);
+							$file =  "$type.$function.$language";
+
+
+							$new_filestore->write($tdata, $this->newObject->id, $file . ".pinp");
+							$new_filestore->touch($this->newObject->id, $file . ".pinp", $tmtime);
 
 							if ($ARCurrent->AXAction == "import") {
 								unset($ARBeenHere[$this->newObject->path]);
+
+								// cleanup old file format
+								$new_filestore->remove($this->id, $file);
 
 								include_once($this->store->get_config("code")."modules/mod_pinp.phtml");
 
@@ -58,13 +64,14 @@ if (! ( $templates && is_array($templates) && !empty($templates) ) && !$ARCurren
 								if ($pinp->error) {
 									$this->newObject->error = $pinp->error;
 								} else {
+
 									$templateCode = $new_filestore->templateCodeFunction($compiled);
 
 									// generating optimized template code
 									$optimized = '<?php $arTemplateFunction = function(&$AR_this) { '.$templateCode.' }; ?>';
 
-									$new_filestore->write($optimized, $this->newObject->id, $type.".".$function.".".$language.".inc");
-									$new_filestore->touch($this->newObject->id,  $type.".".$function.".".$language.".inc", $tmtime);
+									$new_filestore->write($optimized, $this->newObject->id, $file .".inc");
+									$new_filestore->touch($this->newObject->id, $file .".inc", $tmtime);
 								}
 							}
 

--- a/lib/templates/pobject/system.save.layout.phtml
+++ b/lib/templates/pobject/system.save.layout.phtml
@@ -59,6 +59,10 @@
 
 
 				$file=$type.".".$function.".".$language;
+
+				// cleanup old file format
+				$templates->remove($this->id, $file);
+
 				$templates->write($template, $this->id, $file.".pinp");
 				if ($mtime) {
 					$templates->touch($this->id, $file.".pinp", $mtime);
@@ -72,6 +76,7 @@
 				if ($mtime) {
 					$templates->touch($this->id, $file.".inc", $mtime);
 				}
+
 				if ($default) { // add pinp template from default templates list
 					$this->data->config->templates[$type][$function][$language]=$this->id;
 				} else { // remove pinp template from default templates list

--- a/lib/templates/pobject/system.save.layout.phtml
+++ b/lib/templates/pobject/system.save.layout.phtml
@@ -63,11 +63,7 @@
 				if ($mtime) {
 					$templates->touch($this->id, $file.".pinp", $mtime);
 				}
-				$templates->write($compiled, $this->id, $file);
-				if ($mtime) {
-					$templates->touch($this->id, $file, $mtime);
-				}
-				$templateCode = $templates->templateCodeFunction($this->id, $file); 
+				$templateCode = $templates->templateCodeFunction($compiled);
 
 				// generating optimized template code
 				$optimized = '<?php $arTemplateFunction = function(&$AR_this) { '.$templateCode.' }; ?>';


### PR DESCRIPTION
the 'old format' templates where still written to disk, and used for generating the new format compiled templates.

This change:
* removes the need for the old files
* add cleanup code for import and system.save.layout.phtml
* changes the internal api for the filestore
  * templateCodeFunction now has 1 argument, and it doesn't do anything with the filestore anymore


As a result, the function templateCodeFunction should not be defined in the filestore but in a class with as task template management. This is something for the future
