### PR TITLE
Fix for root-path issues under Windows

### DIFF
--- a/lib/configs/ariadne-default.phtml
+++ b/lib/configs/ariadne-default.phtml
@@ -120,6 +120,9 @@
 		$AR->dir->root = $AR->dir->docroot.$AR->dir->www;
 	}
 	$AR->dir->root = (string)\arc\path::collapse($AR->dir->root);
+	if ($AR->dir->docroot[0] !== '/') {
+	    $AR->dir->root = substr($AR->dir->root, 1);
+	}
 
 	/**************************************************************************/
 	/* Only change this if you have made your own loader                      */


### PR DESCRIPTION
The path::collapse() added a leading slash to the root path, which led to unusable paths when Ariadne is installed under windows. The added if-statement checks for a leading slash on the docroot. When it is not found (i.e. windows install), $AR->dir->root is set as a substring of itself, omitting the leading slash.