### PR TITLE
Rework of getPinpTemplate and supporting functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ language: php
 cache: apt
 
 php:
-    - 5.4
     - 5.6
     - 7.0
 

--- a/lib/ar/template.php
+++ b/lib/ar/template.php
@@ -4,6 +4,25 @@
 		private $cache = [];
 
 		private function getStorageLayer($path) {
+			global $AR;
+			if (isset($AR->templateStore)) {
+				$layers = array_keys($AR->templateStore);
+				// fallback
+				$layer = array_reduce($layers, function($carry, $item) use ($path) {
+					if(strpos($path, $item) === 0) {
+						// item is a prefix of item
+						if(!isset($carry) || (strlen($carry) < strlen($item) )) {
+							// item is more specific
+							$carry = $item;
+						}
+					}
+					return $carry;
+				}, null);
+				if(isset($layer)) {
+					$classname = 'ar_template_' .  $AR->templateStore[$layer];
+					return new $classname($path);
+				}
+			}
 			return new ar_template_filestore($path);
 		}
 

--- a/lib/ar/template.php
+++ b/lib/ar/template.php
@@ -19,11 +19,12 @@
 					return $carry;
 				}, null);
 				if(isset($layer)) {
-					$classname = 'ar_template_' .  $AR->templateStore[$layer];
-					return new $classname($path);
+					$config =  $AR->templateStore[$layer];
+					$classname = 'ar_template_' . $config['driver'];
+					return new $classname($layer, $config);
 				}
 			}
-			return new ar_template_filestore($path);
+			return new ar_template_filestore('/',[]);
 		}
 
 		public function get($path, $name){

--- a/lib/ar/template.php
+++ b/lib/ar/template.php
@@ -1,0 +1,40 @@
+<?php
+
+	class ar_template extends arBase {
+		private $cache = [];
+
+		private function getStorageLayer($path) {
+			return new ar_template_filestore($path);
+		}
+
+		public function get($path, $name){
+			return self::getStorageLayer($path)->get($path, $name);
+		}
+
+		public function save($path, $name, $template, $local=null, $private=null) {
+			return self::getStorageLayer($path)->save($path, $name, $template, $local, $private);
+		}
+
+		public function load($path, $name) {
+			return self::getStorageLayer($path)->load($path, $name);
+		}
+
+		public function ls($path) {
+			if (!isset($this->cache[$path])){
+				$this->cache[$path] = self::getStorageLayer($path)->ls($path);
+			}
+			return $this->cache[$path];
+		}
+
+		public function rm($path, $name){
+			return self::getStorageLayer($path)->rm($path, $name);
+		}
+
+		public function exists($path, $name) {
+			return self::getStorageLayer($path)->exists($path, $name);
+		}
+
+		public function compile($path, $name) {
+			return self::getStorageLayer($path)->compile($path, $name);
+		}
+	}

--- a/lib/ar/template/filestore.php
+++ b/lib/ar/template/filestore.php
@@ -1,0 +1,107 @@
+<?php
+
+	class ar_template_filestore extends arBase {
+
+		private function getFilestore() {
+			$context = ar::context()->getObject();
+			if(isset($context)) {
+				$templates = $context->store->get_filestore("templates");
+			} else {
+				global $store;
+				$templates = $store->get_filestore("templates");
+			}
+			return $templates;
+		}
+
+		private function pathToId($path) {
+			$context = ar::context()->getObject();
+
+			if($context->path == $path) {
+				$result = $context->id;
+			} else {
+				$result = $context->loadConfig($path)->id;
+			}
+			return $result;
+		}
+
+		private function getConfig($path) {
+			$context = ar::context()->getObject();
+			return $context->loadConfig($path);
+		}
+
+		public function get($path, $name){
+			$fs = $this->getfilestore();
+			$id = $this->pathtoid($path);
+
+			return (
+				$fs->import($id, $name) 
+			);
+		}
+
+		public function save($path, $name, $template, $local=null, $private=null) {
+			return false;
+		}
+
+		public function load($path, $name) {
+			$fs = $this->getfilestore();
+			$id = $this->pathtoid($path);
+
+			return $fs->read($id, $name . '.pinp');
+		}
+
+		public function ls($path) {
+			$result = [];
+			$fs = $this->getFilestore();
+			$id = $this->pathToId($path);
+
+			$config = $this->getConfig($path);
+
+			$templates = $config->pinpTemplates;
+			foreach($templates as $type => $names) {
+				foreach($names as $name => $languages) {
+					foreach($languages as $language => $id ) {
+						$tempname = sprintf("%s.%s.%s",$type,$name,$language);
+						list($maintype,$subtype) = explode('.', $type, 2);
+						if(!isset($result[$name])) {
+							$result[$name] = [];
+						}
+						$result[$name][] = [
+							'id'       => $config->id,
+							'path'     => $path,
+							'type'     => $maintype,
+							'subtype'  => $subtype,
+							'name'     => $name,
+							'filename' => $tempname,
+							'language' => $language,
+							'private'  => isset($config->privatetemplates[$type][$name]),
+							'local'    => isset($config->localTemplates[$type][$name][$language]),
+						];
+					}
+				}
+			}
+			return $result;
+
+		}
+
+		public function rm($path, $name){
+			$fs = $this->getfilestore();
+			$id = $this->pathtoid($path);
+
+			return (
+				$fs->remove($id, $name) 
+			);
+		}
+
+		public function exists($path, $name) {
+			$fs = $this->getFilestore();
+			$id = $this->pathToId($path);
+
+			return (
+				$fs->exists($id, $name . '.inc') 
+			);
+		}
+
+		public function compile($path, $name) {
+			// FIXME
+		}
+	}

--- a/lib/ar/template/filestore.php
+++ b/lib/ar/template/filestore.php
@@ -74,7 +74,7 @@
 							'filename' => $tempname,
 							'language' => $language,
 							'private'  => isset($config->privatetemplates[$type][$name]),
-							'local'    => isset($config->localTemplates[$type][$name][$language]),
+							'local'    => !isset($config->localTemplates[$type][$name][$language]),
 						];
 					}
 				}

--- a/lib/ar/template/filestore.php
+++ b/lib/ar/template/filestore.php
@@ -57,9 +57,9 @@
 			$config = $this->getConfig($path);
 
 			$templates = $config->pinpTemplates;
-			foreach($templates as $type => $names) {
-				foreach($names as $name => $languages) {
-					foreach($languages as $language => $id ) {
+			if (isset($templates)) foreach($templates as $type => $names) {
+				if (isset($names)) foreach($names as $name => $languages) {
+					if (isset($languages)) foreach($languages as $language => $id ) {
 						$tempname = sprintf("%s.%s.%s",$type,$name,$language);
 						list($maintype,$subtype) = explode('.', $type, 2);
 						if(!isset($result[$name])) {

--- a/lib/ar/template/filesystem.php
+++ b/lib/ar/template/filesystem.php
@@ -41,6 +41,16 @@
 		}
 
 		public function load($path, $name) {
+			$arpath = path::collapse($path);
+
+			if ( strpos($arpath, $this->path, 0) !== 0) {
+				return ar('error')->raiseError('invalide path for loading template',500);
+			}
+
+			$realpath = $this->config['path'] . substr($arpath,strlen($this->path));
+			$realpath = realpath($realpath) .'/';
+
+			return file_get_contents($realpath . $name);
 		}
 
 		public function ls($path) {

--- a/lib/ar/template/filesystem.php
+++ b/lib/ar/template/filesystem.php
@@ -1,0 +1,141 @@
+<?php
+
+	use arc\path as path;
+
+	class ar_template_filesystem extends arBase {
+		private $path;
+		private $config;
+
+		public function __construct($path, $config ) {
+			$this->path   = path::collapse($path);
+			$this->config = $config;
+			$this->config['path'] = path::collapse($config['path']);
+		}
+
+		public function get($path, $name){
+			$arpath = path::collapse($path);
+
+			if ( strpos($arpath, $this->path, 0) !== 0) {
+				return ar('error')->raiseError('invalide path for loading template',500);
+			}
+
+			$realpath = $this->config['path'] . substr($arpath,strlen($this->path));
+			$realpath = realpath($realpath) .'/';
+
+			// FIXME 'netjes' een path opzoeken hier voor
+			$cachepath = sha1($path . $name);
+			$cacheroot = '/home/muller/devel/site/files/temp/';
+			if ( 
+				! file_exists( $cacheroot . $cachepath )  ||
+				( filemtime($cacheroot . $cachepath ) < filemtime ( $realpath  . $name ) )
+			) {
+				$compiled = $this->compile($path, $name);
+				file_put_contents($cacheroot . $cachepath, $compiled);
+			}
+			include (  $cacheroot . $cachepath );
+			return $arTemplateFunction;
+		}
+
+		public function save($path, $name, $template, $local=null, $private=null) {
+			return false;
+		}
+
+		public function load($path, $name) {
+		}
+
+		public function ls($path) {
+			$arpath = path::collapse($path);
+
+			if ( strpos($arpath, $this->path, 0) !== 0) {
+				return [];
+			}
+			$realpath = $this->config['path'] . substr($arpath,strlen($this->path));
+			$realpath = realpath($realpath) .'/';
+			$config = json_decode(file_get_contents($realpath . 'library.json'),true);
+			if(!isset($config['exports']) ) {
+				$config['exports'] = [];
+			}
+			if(!isset($config['local']) ) {
+				$config['local'] = [];
+			}
+
+			$result = [];
+
+			$traverseDir = function ($path, $type = 'pobject', $nls = 'any') use ($arpath, &$result, $config, &$traverseDir, $realpath) {
+				$path = path::collapse($path);
+				$index = scandir($path, SCANDIR_SORT_NONE);
+				if($index !== false) {
+					list($maintype, $subtype) = explode('.', $type,2);
+					foreach($index as $filename) {
+						if($filename[0] === "." ) {
+							continue;
+						}
+						$filepath = $path . $filename;
+						if ( is_dir($filepath) ) {
+							if (strlen($filename) == 2) {
+								$traverseDir(path::collapse($filename, $path), $type, $filename);
+							} else {
+								$traverseDir(path::collapse($filename, $path), $filename);
+							}
+						} else if ( is_file($filepath) ) {
+							$tempname = sprintf("%s.%s.%s",$type,$filename,$nls);
+							$confname = sprintf("%s::%s",$type,$filename);
+							$private = true;
+							if (isset( $config['exports'] ) ) {
+								$private = ! in_array($confname, $config['exports']);
+							}
+							$local = false;
+							if (isset( $config['local'] ) ) {
+								$local = in_array($confname, $config['local']);
+							}
+							$result[$filename][] = [
+								'id'       => PHP_INT_MAX,
+								'path'     => $arpath,
+								'type'     => $maintype,
+								'subtype'  => $subtype,
+								'name'     => $tempname,
+								'filename' => substr($filepath,strlen($realpath)),
+								'language' => $nls,
+								'private'  => $private,
+								'local'    => $local,
+							];
+						}
+					}
+				}
+
+			};
+			$traverseDir($realpath . 'src/');
+			return $result;
+		}
+
+		public function rm($path, $name){
+		}
+
+		public function exists($path, $name) {
+			return true;
+		}
+
+		public function compile($path, $name) {
+			global $AR;
+			$arpath = path::collapse($path);
+
+			if ( strpos($arpath, $this->path, 0) !== 0) {
+				return ar('error')->raiseError('invalide path for loading template',500);
+			}
+
+			$realpath = $this->config['path'] . substr($arpath,strlen($this->path));
+			$realpath = realpath($realpath) .'/';
+
+			$template = file_get_contents($realpath . $name);
+
+			require_once(AriadneBasePath."/modules/mod_pinp.phtml");
+
+			$pinp = new pinp($AR->PINP_Functions, "local->", "\$AR_this->_");
+
+			// FIXME error checking
+			$compiled = $pinp->compile(strtr($template,"\r",""));
+			$compiled = sprintf($AR->PINPtemplate, $compiled);
+			return $compiled;
+
+		}
+	}

--- a/lib/ar/template/filesystem.php
+++ b/lib/ar/template/filesystem.php
@@ -112,7 +112,15 @@
 		}
 
 		public function exists($path, $name) {
-			return true;
+			$arpath = path::collapse($path);
+
+			if ( strpos($arpath, $this->path, 0) !== 0) {
+				return ar('error')->raiseError('invalide path for loading template',500);
+			}
+
+			$realpath = $this->config['path'] . substr($arpath,strlen($this->path));
+			$realpath = realpath($realpath) .'/';
+			return file_exists($realpath . $name);
 		}
 
 		public function compile($path, $name) {

--- a/lib/objects/ariadne_object.php
+++ b/lib/objects/ariadne_object.php
@@ -1973,7 +1973,7 @@ abstract class ariadne_object extends object { // ariadne_object class definitio
 									echo "<!-- arTemplateStart\nData: ".$this->type." ".$this->path." \nTemplate: ".$template["arCallTemplatePath"]." ".$template["arCallTemplate"]." \nLibrary:".$template["arLibrary"]." -->";
 								}
 								set_error_handler(array('pobject','pinpErrorHandler'),error_reporting());
-								$func = $arTemplates->import($template["arTemplateId"], $template["arCallTemplate"]);
+								$func = ar('template')->get($template['arCallTemplatePath'],$template['arCallTemplate']);
 								if(is_callable($func)){
 									$arResult = $func($this);
 								}
@@ -2642,7 +2642,7 @@ abstract class ariadne_object extends object { // ariadne_object class definitio
 				}
 				if ( $continue ) {
 					set_error_handler(array('pobject','pinpErrorHandler'),error_reporting());
-					$func = $arTemplates->import($template["arTemplateId"], $template["arCallTemplate"]);
+					$func = ar('template')->get($template['arCallTemplatePath'],$template['arCallTemplate']);
 					if(is_callable($func)){
 						$arResult = $func($this);
 					}

--- a/lib/objects/ariadne_object.php
+++ b/lib/objects/ariadne_object.php
@@ -1312,19 +1312,13 @@ abstract class ariadne_object extends object { // ariadne_object class definitio
 		if (!$ARConfig->cache[$this->path] && $context["scope"] != "pinp") {
 			// first inherit parent configuration data
 			$configcache= clone $ARConfig->cache[$this->parent];
-			unset($configcache->localTemplates);
+			$configcache->localTemplates = [];
 			// cache default templates
 			if (isset($this->data->config->templates) && count($this->data->config->templates)) {
-				$configcache->templates=&$this->data->config->templates;
-			}
-			if (isset($this->data->config->privatetemplates) && count($this->data->config->privatetemplates)) {
-				$configcache->privatetemplates=&$this->data->config->privatetemplates;
-			}
+				$configcache->templates        = $this->data->config->templates;
+				$configcache->privatetemplates = $this->data->config->privatetemplates;
+				$configcache->localTemplates   = $this->data->config->templates;
 
-			// Speedup check for config.ini
-
-			if(isset($this->data->config->templates) && is_array($this->data->config->templates) ) {
-				$configcache->localTemplates = $this->data->config->templates;
 				if( !$configcache->hasDefaultConfigIni ) {
 					foreach($this->data->config->templates as $type => $templates ) {
 						if( isset($templates["config.ini"]) ) {

--- a/lib/objects/ariadne_object.php
+++ b/lib/objects/ariadne_object.php
@@ -1664,29 +1664,27 @@ abstract class ariadne_object extends object { // ariadne_object class definitio
 				if (isset($ARConfig->libraries[$checkpath])) {
 					// need to check for unnamed libraries
 					$libraries = array_filter($ARConfig->libraries[$checkpath],'is_int',ARRAY_FILTER_USE_KEY);
+					foreach( $libraries as $libpath ) {
+						$next = 0;
+						do {
+							$template = $this->findTemplateOnPath( [ $libpath ], $arCallFunction, $arCallType, $reqnls, $arSuperContext);
 
-					do  {
-						$template = $this->findTemplateOnPath( $libraries, $arCallFunction, $arCallType, $reqnls, $arSuperContext);
-						//var_dump($template,$libraries);
-						if (!isset($template)) {
-							$libraries = array_map( function($path) use ($top, $ARConfig) {
-								$prefix = substr($ARConfig->cache[$path]->type,0,8);
-								if ($prefix === 'psection') {
-									return false;
-								}
+							if (isset($template)) {
+								break 2;
+							}
 
-								$parent = $this->store->make_path($path, "..");
+							$prefix = substr($ARConfig->cache[$libpath]->type,0,8);
+							if ($prefix === 'psection') {
+								$next = 1;
+							}
+							$libparent = $this->store->make_path($libpath, "..");
 
-								if ( $path == $parent || $top == $path) {
-									return false;
-								}
-								return $parent;
-							}, $libraries);
-
-							// remove all unneeded libraries
-							$libraries = array_filter($libraries);
-						}
-					} while(!isset($template) && count($libraries) );
+							if ( $libpath == $libparent || $top == $libpath) {
+								$next = 1;
+							}
+							$libpath = $libparent;
+						} while ($next == 0);
+					}
 					debug("getPinpTemplate: found ".$arCallFunction." on ".$template['path']);
 				}
 

--- a/lib/objects/ariadne_object.php
+++ b/lib/objects/ariadne_object.php
@@ -1583,20 +1583,23 @@ abstract class ariadne_object extends object { // ariadne_object class definitio
 			$arSuperContext = array();
 		}
 
-		$typepos = strpos($arCallFunction,"::");
-		if ($typepos !== false ) {
-			// template of a specific class defined via call("class::template");
-			$arCallType     = substr($arCallFunction, 0, $typepos);
-			$arCallFunction = substr($arCallFunction, $typepos+1);
+		$matches = [];
+		preg_match('/^
+		    ( (?<libname> [^:]+) :  )?
+		    ( (?<calltype>[^:]+) :: )?
+		      (?<template>[^:]+)
+		    $/x', $arCallFunction, $matches);
+
+		$arCallFunction = $matches['template'];
+
+		if($matches['calltype'] != '') {
+			$arCallType = $matches['calltype'];
 		} else {
-			$arCallType=$this->type;
+			$arCallType = $this->type;
 		}
 
-		$libpos = strpos($arCallFunction,":");
-		if ( $libpos !== false ) {
-			// template of a specific library defined via call("library:template");
-			$arLibrary      = substr($arCallFunction, 0, $libpos);
-			$arCallFunction = substr($arCallFunction, $libpos+1);
+		if ( $matches['libname'] != '' ) {
+			$arLibrary      = $matches['libname'];
 
 			if ($arLibrary == 'current') {
 				// load the current arLibrary

--- a/lib/objects/ariadne_object.php
+++ b/lib/objects/ariadne_object.php
@@ -1658,7 +1658,10 @@ abstract class ariadne_object extends object { // ariadne_object class definitio
 				if (isset($ARConfig->libraries[$checkpath])) {
 					// need to check for unnamed libraries
 					$libraries = array_filter($ARConfig->libraries[$checkpath],'is_int',ARRAY_FILTER_USE_KEY);
-					foreach( $libraries as $libpath ) {
+					foreach( $libraries as $key => $libpath ) {
+						$arLibraryPath = $libpath;
+						$arLibrary     = $key;
+
 						$libprevpath = null;
 						while($libpath != $libprevpath ) {
 							$libprevpath = $libpath;

--- a/lib/objects/ariadne_object.php
+++ b/lib/objects/ariadne_object.php
@@ -2597,8 +2597,8 @@ abstract class ariadne_object extends object { // ariadne_object class definitio
 			$template = $this->getPinpTemplate($arCallFunction, $this->path, '', false, $arLibrariesSeen, $arSuperContext);
 		}
 		if ($template["arCallTemplate"] && $template["arTemplateId"]) {
-			$arTemplates=$this->store->get_filestore("templates");
-			if ($arTemplates->exists($template["arTemplateId"], $template["arCallTemplate"].".inc")) {
+			$exists = ar('template')->exists($template['arCallTemplatePath'],$template["arCallTemplate"]);
+			if ( $exists ) {
 				debug("call_super: found template ".$template["arCallTemplate"]." on object with id ".$template["arTemplateId"]);
 				$arLibrary = $template['arLibrary'];
 				debug("call_super: found template on ".$template["arTemplateId"]);

--- a/lib/objects/ariadne_object.php
+++ b/lib/objects/ariadne_object.php
@@ -1521,11 +1521,9 @@ abstract class ariadne_object extends object { // ariadne_object class definitio
 
 	protected function findTemplateOnPath($path, $arCallFunction, $arType, $reqnls, &$arSuperContext){
 
-		debug('findTemplateOnPath: ['.$arType .']['.$arCallFunction.']['.$reqnls.']');
 		while ($arType!='ariadne_object' ) {
 			list($arMatchType,$arMatchSubType) = explode('.',$arType,2);
 			$local = ($path === $this->path);
-			debug("findTemplateOnPath context [". $path.":".$arType.":".$arCallFunction ."]");
 			$templates = ar('template')->ls($path);
 			if(isset($templates[$arCallFunction])) {
 				$template = null;
@@ -1544,7 +1542,6 @@ abstract class ariadne_object extends object { // ariadne_object class definitio
 					}, null);
 				}
 				if ( isset($template) && !isset($arSuperContext[$path.":".$arType.":".$arCallFunction])) {
-					debug("findTemplateOnPath returning for [". $path.":".$arType.":".$arCallFunction ."]");
 					return $template;
 				}
 			}
@@ -1629,7 +1626,6 @@ abstract class ariadne_object extends object { // ariadne_object class definitio
 				debug("getPinpTemplate: Failed to find library $arLibrary");
 			}
 			$path = $this->make_path($path);
-			debug("final lib path is ".$path);
 		}
 
 		$checkpath           = $path;
@@ -1638,21 +1634,20 @@ abstract class ariadne_object extends object { // ariadne_object class definitio
 		$reqnls              = $this->reqnls;
 		$template            = null;
 		while (!$arCallClassTemplate && !isset($template) && $checkpath!=$lastcheckedpath) {
-			debug("getPinpTemplate: checking for ".$arCallFunction." on ".$checkpath);
 			$lastcheckedpath = $checkpath;
 
 			$template = $this->findTemplateOnPath( $checkpath, $arCallFunction, $arCallType, $reqnls, $arSuperContext);
 
 			if (isset($template)) {
 				// haal info uit template
-				debug("getPinpTemplate: found ".$arCallFunction." on ".$checkpath);
+				// debug("getPinpTemplate: found ".$arCallFunction." on ".$checkpath);
 			} else if ($inLibrary) {
 
 				// faster matching on psection, prefix doesn't have to be a valid type
 				$prefix = substr($ARConfig->cache[$checkpath]->type,0,8);
 
 				if ($prefix === 'psection') {
-					 debug("BREAKING; $arTemplateId");
+					 // debug("BREAKING; $arTemplateId");
 					// break search operation when we have found a
 					// psection object
 					break;
@@ -1698,7 +1693,7 @@ abstract class ariadne_object extends object { // ariadne_object class definitio
 		$result = null;
 		if(isset($template)) {
 			$result = [];
-			debug("getPinpTemplate END; ".$template['id'] .' '.$template['path']);
+			//debug("getPinpTemplate END; ".$template['id'] .' '.$template['path']);
 			$type = $template['type'];
 			if(isset($template['subtype'])) {
 				$type .= '.' . $template['subtype'];

--- a/lib/objects/ariadne_object.php
+++ b/lib/objects/ariadne_object.php
@@ -1525,7 +1525,8 @@ abstract class ariadne_object extends object { // ariadne_object class definitio
 		}
 
 		debug('findTemplateOnPath: ['.$arType .']['.$arCallFunction.']['.$reqnls.']');
-		while ($arType!='ariadne_object' && !$arCallTemplate  ) {
+		while ($arType!='ariadne_object' ) {
+			list($arMatchType,$arMatchSubType) = explode('.',$arType,2);
 			foreach($paths as $path) {
 				debug("findTemplateOnPath context [". $path.":".$arType.":".$arCallFunction ."]");
 				$templates = ar('template')->ls($path);
@@ -1534,8 +1535,8 @@ abstract class ariadne_object extends object { // ariadne_object class definitio
 				}
 				$template = null;
 				if (!isset($arSuperContext[$path.":".$arType.":".$arCallFunction])) {
-					$template = array_reduce($templates[$arCallFunction] , function($carry, $item) use ($arType, $reqnls) {
-						if ($item['type'] === $arType) {
+					$template = array_reduce($templates[$arCallFunction] , function($carry, $item) use ($arMatchType,$arMatchSubType, $reqnls) {
+						if ($item['type'] === $arMatchType && ($item['subtype'] == $arMatchSubType)) {
 							if (isset($carry) && $carry['language'] !== 'any') {
 								return $carry;
 							} else if ($item['language'] === 'any' || $item['language'] === $reqnls ) {
@@ -1700,8 +1701,12 @@ abstract class ariadne_object extends object { // ariadne_object class definitio
 		if(isset($template)) {
 			$result = [];
 			debug("getPinpTemplate END; ".$template['id'] .' '.$template['path']);
+			$type = $template['type'];
+			if(isset($template['subtype'])) {
+				$type .= '.' . $template['subtype'];
+			}
 			$result["arTemplateId"]       = $template['id'];
-			$result["arCallTemplate"]     = sprintf("%s.%s.%s",$template['type'],$arCallFunction,$template['language']);
+			$result["arCallTemplate"]     = sprintf("%s.%s.%s",$type,$arCallFunction,$template['language']);
 			$result["arCallType"]         = $arCallType;
 			$result["arCallTemplateName"] = $arCallFunction;
 			$result["arCallTemplateNLS"]  = $template['language'];

--- a/lib/objects/ariadne_object.php
+++ b/lib/objects/ariadne_object.php
@@ -1528,6 +1528,7 @@ abstract class ariadne_object extends object { // ariadne_object class definitio
 		while ($arType!='ariadne_object' ) {
 			list($arMatchType,$arMatchSubType) = explode('.',$arType,2);
 			foreach($paths as $path) {
+				$local = ($path === $this->path);
 				debug("findTemplateOnPath context [". $path.":".$arType.":".$arCallFunction ."]");
 				$templates = ar('template')->ls($path);
 				if(!isset($templates[$arCallFunction])) {
@@ -1535,12 +1536,14 @@ abstract class ariadne_object extends object { // ariadne_object class definitio
 				}
 				$template = null;
 				if (!isset($arSuperContext[$path.":".$arType.":".$arCallFunction])) {
-					$template = array_reduce($templates[$arCallFunction] , function($carry, $item) use ($arMatchType,$arMatchSubType, $reqnls) {
-						if ($item['type'] === $arMatchType && ($item['subtype'] == $arMatchSubType)) {
-							if (isset($carry) && $carry['language'] !== 'any') {
-								return $carry;
-							} else if ($item['language'] === 'any' || $item['language'] === $reqnls ) {
-								return $item;
+					$template = array_reduce($templates[$arCallFunction] , function($carry, $item) use ($arMatchType,$arMatchSubType, $reqnls, $local) {
+						if ( ( $item['local'] == true && $local == true ) || $item['local'] == false ) {
+							if ($item['type'] === $arMatchType && ($item['subtype'] == $arMatchSubType) ) {
+								if (isset($carry) && $carry['language'] !== 'any') {
+									return $carry;
+								} else if ($item['language'] === 'any' || $item['language'] === $reqnls ) {
+									return $item;
+								}
 							}
 						}
 						return $carry;
@@ -1710,7 +1713,7 @@ abstract class ariadne_object extends object { // ariadne_object class definitio
 			$result["arCallType"]         = $arCallType;
 			$result["arCallTemplateName"] = $arCallFunction;
 			$result["arCallTemplateNLS"]  = $template['language'];
-			$result["arCallTemplateType"] = $template['type'];
+			$result["arCallTemplateType"] = $type;
 			$result["arCallTemplatePath"] = $template['path'];
 			$result["arLibrary"]          = $arLibrary;
 			$result["arLibraryPath"]      = $arLibraryPath;

--- a/lib/objects/ariadne_object.php
+++ b/lib/objects/ariadne_object.php
@@ -1709,7 +1709,7 @@ abstract class ariadne_object extends object { // ariadne_object class definitio
 				$type .= '.' . $template['subtype'];
 			}
 			$result["arTemplateId"]       = $template['id'];
-			$result["arCallTemplate"]     = sprintf("%s.%s.%s",$type,$arCallFunction,$template['language']);
+			$result["arCallTemplate"]     = $template['filename'];
 			$result["arCallType"]         = $arCallType;
 			$result["arCallTemplateName"] = $arCallFunction;
 			$result["arCallTemplateNLS"]  = $template['language'];


### PR DESCRIPTION
* use ar/template for the 'get template and make it a closure' logic
* support for templates 'outside' ariadne control
* rework of the get template code, this also removes all the caching in template code

this is still a work in progress and not all code paths use the new logic
* all the template editing logic still use the old code paths
* ar/template is read only for now, the write paths are not yet supported
