### PR TITLE
fix for stripARNameSpace

### DIFF
--- a/lib/modules/mod_htmlcleaner.php
+++ b/lib/modules/mod_htmlcleaner.php
@@ -265,7 +265,7 @@ class htmlcleaner
 				$_buffer .= $chr;
 				if ($chr == '"' || $chr == "'") {
 
-					$regexp = '|'.$chr.'(.*?)'.$chr.'|';
+					$regexp = '|'.$chr.'(.*?)'.$chr.'|sm';
 					preg_match($regexp,$str,$matches,0,$i);
 
 					$_buffer .= $matches[1] . $chr;


### PR DESCRIPTION
fixed issue in stripARNameSpace if attributes span over multiple lines

for example:

<span style="font-size:10.5pt;font-family:&quot;Helvetica&quot;,sans-serif;
mso-ansi-language: NL">Hello world<br></span>